### PR TITLE
Add 'import.meta.url' support

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -61,10 +61,20 @@ if (!self.define) {
     }
     registry[moduleName] = new Promise(async resolve => {
       let exports = {};
+      const module = {
+        // #ifdef publicPath
+        uri: location.origin + // #put "'" + publicPath + "' + moduleName.slice(1)"
+        // #else
+        uri: location.origin + moduleName.slice(1)
+        // #endif
+      };
       const deps = await Promise.all(
         depsNames.map(depName => {
           if (depName === "exports") {
             return exports;
+          }
+          if (depName === "module") {
+            return module;
           }
           return singleRequire(depName);
         })


### PR DESCRIPTION
Rollup transforms `import.meta.url` to `module.uri`. This adds support using `location.origin`, `publicPath`, and `moduleName`.

[REPL example](https://rollupjs.org/repl?version=0.66.6&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMmltcG9ydC5tZXRhLnVybCUzQiUyMiU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlMjJmb3JtYXQlMjIlM0ElMjJhbWQlMjIlMkMlMjJuYW1lJTIyJTNBJTIybXlCdW5kbGUlMjIlMkMlMjJhbWQlMjIlM0ElN0IlMjJpZCUyMiUzQSUyMiUyMiU3RCU3RCUyQyUyMmV4YW1wbGUlMjIlM0FudWxsJTdE)